### PR TITLE
adding in basic client-side rate-limiting for kai-api, 60 increments …

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -67,20 +67,20 @@ test("validate rate-limiting", () => {
 
   //Both increments should count against rate limit, resulting in 60 here
   result = kai.incrementCounter("0", 60);
-  expect(result).toEqual(58);
+  expect(result).toEqual(8);
 
   //Subsequent additions and subtractions should be ignored
   result = kai.incrementCounter("0", 100);
-  expect(result).toEqual(58);
+  expect(result).toEqual(8);
   result = kai.incrementCounter("0", -100);
-  expect(result).toEqual(58);
+  expect(result).toEqual(8);
 
   //Let's pretend time skipped ahead a minute
   jest.useFakeTimers().setSystemTime(Date.now() + 60001); 
 
   //Should be able to increment again now 
   result = kai.incrementCounter("0", 1);
-  expect(result).toEqual(59);
+  expect(result).toEqual(9);
 
   //But only up to 60, total
   result = kai.incrementCounter("0", -60);

--- a/index.test.ts
+++ b/index.test.ts
@@ -1,7 +1,90 @@
 import { Kai } from "./index";
 
+const getDummyWebSocket = () => {
+  return {
+    readyState: 3,
+    addEventListener: (eventName: string, listener: Function) => {
+      if(eventName === "message") {
+        const initialCounters = JSON.stringify({
+          messageType: "counter",
+          counter: [
+            {id:"0",count:0},
+            {id:"1",count:0},
+            {id:"2",count:0},
+            {id:"3",count:0},
+            {id:"4",count:0},
+            {id:"5",count:0},
+            {id:"6",count:0},
+            {id:"7",count:0},
+            {id:"8",count:0},
+            {id:"9",count:0},
+          ]
+        })
+        listener.call(this, {data:initialCounters});
+      } else if (eventName === "open") {
+        listener.call(this);
+      }
+    },
+    send: (data: string | ArrayBufferLike | Blob | ArrayBufferView) => {},
+    close: () => {}
+  }
+}
+
 test("construct kai", () => {
   // Let's just test that we can at least construct a kai
   // object.
-  const kai = new Kai();
+  const fakeBearer = "testing-purposes-only";
+  const fakeWebSocket = getDummyWebSocket();
+
+  const kai = new Kai(fakeWebSocket, fakeBearer);
+});
+
+test("get counters", () => {
+  // Let's just test that we can at least construct a kai
+  // object.
+  const fakeBearer = "testing-purposes-only";
+  const fakeWebSocket = getDummyWebSocket();
+
+  const kai = new Kai(fakeWebSocket, fakeBearer);
+  const counters = kai.getCounters();
+  expect(counters).toBeInstanceOf(Map);
+  expect(counters.get("1")).toEqual(0);
+});
+
+test("validate rate-limiting", () => {
+  const fakeBearer = "testing-purposes-only";
+  const fakeWebSocket = getDummyWebSocket();
+
+  const kai = new Kai(fakeWebSocket, fakeBearer);
+
+  //should be able to increment in positive direction
+  let result = kai.incrementCounter("0", 1);
+  expect(result).toEqual(1);
+  
+  //should be able to increment in negative direction
+  result = kai.incrementCounter("0", -1);
+  expect(result).toEqual(0);
+
+  //Both increments should count against rate limit, resulting in 60 here
+  result = kai.incrementCounter("0", 60);
+  expect(result).toEqual(58);
+
+  //Subsequent additions and subtractions should be ignored
+  result = kai.incrementCounter("0", 100);
+  expect(result).toEqual(58);
+  result = kai.incrementCounter("0", -100);
+  expect(result).toEqual(58);
+
+  //Let's pretend time skipped ahead a minute
+  jest.useFakeTimers().setSystemTime(Date.now() + 60001); 
+
+  //Should be able to increment again now 
+  result = kai.incrementCounter("0", 1);
+  expect(result).toEqual(59);
+
+  //But only up to 60, total
+  result = kai.incrementCounter("0", -60);
+  expect(result).toEqual(0);
+
+
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kaimerra-corp/kai-api",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kaimerra-corp/kai-api",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "UNLICENSED",
       "dependencies": {
         "eventemitter3": "^4.0.7"

--- a/rate-limit.ts
+++ b/rate-limit.ts
@@ -12,7 +12,12 @@ export class RateLimiter {
     }
 
     ready(): boolean {
-        return this.currentRate < this.rateLimit || this.lastClearTime + this.timeLimit < Date.now();
+        const result = this.currentRate < this.rateLimit || this.lastClearTime + this.timeLimit < Date.now();
+        if (!result) {
+            const waitTime = this.lastClearTime + this.timeLimit - Date.now();
+            console.log("attempt to exceed the rate limit denied, please wait " + waitTime + " ms");
+        }
+        return result;
     }
     
     use(rate: number): number {
@@ -22,6 +27,8 @@ export class RateLimiter {
         } else {
             if(this.currentRate >= this.rateLimit) {
                 //Short-circuit if we're at the rate limit
+                const waitTime = this.lastClearTime + this.timeLimit - Date.now();
+                console.log("attempt to exceed the rate limit denied, please wait " + waitTime + " ms");
                 return 0;
             }
         }

--- a/rate-limit.ts
+++ b/rate-limit.ts
@@ -1,0 +1,39 @@
+export class RateLimiter {
+    timeLimit: number;
+    lastClearTime: number;
+    currentRate: number;
+    rateLimit: number;
+
+    constructor(rateLimit: number, timeLimit: number) {
+        this.rateLimit = rateLimit;
+        this.timeLimit = timeLimit;
+        this.currentRate = 0;
+        this.lastClearTime = Date.now();
+    }
+
+    ready(): boolean {
+        return this.currentRate < this.rateLimit || this.lastClearTime + this.timeLimit < Date.now();
+    }
+    
+    use(rate: number): number {
+        if(this.lastClearTime + this.timeLimit < Date.now()) {
+            this.lastClearTime = Date.now();
+            this.currentRate = 0;
+        } else {
+            if(this.currentRate >= this.rateLimit) {
+                //Short-circuit if we're at the rate limit
+                return 0;
+            }
+        }
+
+        //Apply bounding to increment in case it would put the change over the rate limit
+        let boundedRate = rate;
+        const newRate = this.currentRate + Math.abs(rate);
+        if(newRate > this.rateLimit) {
+            boundedRate += (newRate - this.rateLimit) * (rate > 0 ? -1 : 1);
+        }
+
+        this.currentRate += + Math.abs(rate);
+        return boundedRate;
+    }
+}


### PR DESCRIPTION
…per counter per minute!

Also added in some tests to validate basic functionality alongside rate limiting behavior, and a basic dummy socket mock that initializes all counters to zero and never receives any updates from the backend.